### PR TITLE
Add automatic installation for WesanoxMatrixContent module

### DIFF
--- a/WesanoxAccessibilityTool.module
+++ b/WesanoxAccessibilityTool.module
@@ -15,7 +15,7 @@ class WesanoxAccessibilityTool extends WireData implements Module, ConfigurableM
             'icon' => 'male',
             'singular' => true,
             'autoload' => true,
-            'installs' => ['LanguageSupport', 'LanguageSupportFields', 'LanguageSupportPageNames', 'LanguageTabs'],
+            'installs' => ['LanguageSupport', 'LanguageSupportFields', 'LanguageSupportPageNames', 'LanguageTabs', 'WesanoxMatrixContent'],
             'requires' => array(
                 'ProcessWire>=3.0.210',
                 'PHP>=8.0.0',


### PR DESCRIPTION
Updated the WesanoxAccessibilityTool module to include the WesanoxMatrixContent module as a dependency. Introduced functionality to download and install external modules dynamically if they are not already present.